### PR TITLE
Current version 0.5.0 using Terraform 1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        python-version: [ '3.7.9', '3.8.10', '3.9.13', '3.10.11', '3.11.5' ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
@@ -18,7 +18,7 @@ jobs:
       - name: Set up GoLang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        python-version: [ '3.7.9', '3.8.10', '3.9.13', '3.10.11', '3.11.5' ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
@@ -15,7 +15,7 @@ jobs:
       - name: Set up GoLang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,18 @@ test: clean-pyc
 build:
 	$(PY3) -m poetry build -f wheel
 
+build-all:
+	$(PY3) -m poetry env use python3.7
+	$(PY3) -m poetry build -f wheel
+	$(PY3) -m poetry env use python3.8
+	$(PY3) -m poetry build -f wheel
+	$(PY3) -m poetry env use python3.9
+	$(PY3) -m poetry build -f wheel
+	$(PY3) -m poetry env use python3.10
+	$(PY3) -m poetry build -f wheel
+	$(PY3) -m poetry env use python3.11
+	$(PY3) -m poetry build -f wheel
+
 publish:
 	$(PY3) -m poetry publish
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![libterraform](https://img.shields.io/pypi/v/libterraform.svg)](https://pypi.python.org/pypi/libterraform)
 [![libterraform](https://img.shields.io/pypi/l/libterraform.svg)](https://pypi.python.org/pypi/libterraform)
 [![libterraform](https://img.shields.io/pypi/pyversions/libterraform.svg)](https://pypi.python.org/pypi/libterraform)
-[![Test](https://github.com/Prodesire/py-libterraform/actions/workflows/test.yml/badge.svg)](https://github.com/Prodesire/py-libterraform/actions/workflows/release.yml)
+[![Test](https://github.com/Prodesire/py-libterraform/actions/workflows/test.yml/badge.svg)](https://github.com/Prodesire/py-libterraform/actions/workflows/test.yml)
 [![libterraform](https://img.shields.io/pypi/dm/libterraform)](https://pypi.python.org/pypi/libterraform)
 
 Python binding for [Terraform](https://www.terraform.io/).
@@ -89,6 +89,7 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 
 | libterraform                                          | Terraform                                                   |
 |-------------------------------------------------------|-------------------------------------------------------------|
+| [0.5.0](https://pypi.org/project/libterraform/0.5.0/) | [1.3.0](https://github.com/hashicorp/terraform/tree/v1.3.0) |
 | [0.4.0](https://pypi.org/project/libterraform/0.4.0/) | [1.2.2](https://github.com/hashicorp/terraform/tree/v1.2.2) |
 | [0.3.1](https://pypi.org/project/libterraform/0.3.1/) | [1.1.7](https://github.com/hashicorp/terraform/tree/v1.1.7) |
 
@@ -96,8 +97,8 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 
 If you want to develop this library, should first prepare the following environments:
 
-- [GoLang](https://go.dev/dl/) (Version 1.17.x or 1.16.x)
-- [Python](https://www.python.org/downloads/) (Version 3.6~3.10)
+- [GoLang](https://go.dev/dl/) (Version 1.18+)
+- [Python](https://www.python.org/downloads/) (Version 3.7~3.10)
 - GCC
 
 Then, initialize git submodule:

--- a/libterraform/__init__.py
+++ b/libterraform/__init__.py
@@ -2,7 +2,7 @@ import os
 from ctypes import cdll, c_void_p
 from libterraform.common import WINDOWS
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 root = os.path.dirname(os.path.abspath(__file__))
 _lib_filename = 'libterraform.dll' if WINDOWS else 'libterraform.so'

--- a/libterraform/cli.py
+++ b/libterraform/cli.py
@@ -584,7 +584,7 @@ class TerraformCommand:
 
     def fmt(
             self,
-            dir: str = None,
+            dir: Union[str, List[str]] = None,
             check: bool = False,
             no_color: bool = True,
             list: bool = None,
@@ -626,7 +626,12 @@ class TerraformCommand:
             check=flag(check_input),
             recursive=flag(recursive),
         )
-        args = [dir] if dir else None
+        if dir:
+            args = dir
+            if not isinstance(dir, List):
+                args = [dir]
+        else:
+            args = None
         retcode, stdout, stderr = self.run('fmt', args, options=options, chdir=self.cwd, check=check)
         return CommandResult(retcode, stdout, stderr, json=False)
 
@@ -704,7 +709,6 @@ class TerraformCommand:
             id: str,
             check: bool = False,
             config: str = None,
-            allow_missing_config: bool = None,
             input: bool = False,
             lock: bool = None,
             lock_timeout: str = None,
@@ -745,7 +749,6 @@ class TerraformCommand:
             to use to configure the provider. Defaults to pwd.
             If no config files are present, they must be provided
             via the input prompts or env vars.
-        :param allow_missing_config: True to allow import when no resource configuration block exists.
         :param input: False to disable interactive prompts. Note that some actions may
             require interactive prompts and will error if input is disabled.
         :param lock: False to not hold a state lock during backend migration.
@@ -763,7 +766,6 @@ class TerraformCommand:
         """
         options.update(
             config=config,
-            allow_missing_config=flag(allow_missing_config),
             input=input,
             lock=lock,
             lock_timeout=lock_timeout,
@@ -798,6 +800,7 @@ class TerraformCommand:
         :param json: Whether to load stdout as json.
         :param no_color: True to output not contain any color.
         :param state: Path to the state file to read. Defaults to "terraform.tfstate".
+            Ignored when remote state is used.
         :param raw: For value types that can be automatically converted to a string,
             will print the raw string directly, rather than a human-oriented
             representation of the value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libterraform"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python binding for Terraform."
 authors = ["Prodesire <wangbinxin001@126.com>"]
 license = "MIT"
@@ -30,7 +30,7 @@ packages = [
 include = ["libterraform/libterraform.so", "libterraform/libterraform.dll"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.1"

--- a/tests/cli/test_fmt.py
+++ b/tests/cli/test_fmt.py
@@ -1,7 +1,7 @@
 import re
 
 from libterraform import TerraformCommand
-from tests.consts import TF_SLEEP_DIR
+from tests.consts import TF_SLEEP_DIR, TF_SLEEP2_DIR
 
 
 class TestTerraformCommandFmt:
@@ -13,5 +13,11 @@ class TestTerraformCommandFmt:
     def test_fmt_dir(self):
         cli = TerraformCommand()
         r = cli.fmt(TF_SLEEP_DIR, list=False, write=False, diff=False, recursive=True)
+        assert r.retcode == 0, r.error
+        assert r.value
+
+    def test_fmt_dirs(self):
+        cli = TerraformCommand()
+        r = cli.fmt([TF_SLEEP_DIR, TF_SLEEP2_DIR], list=False, write=False, diff=False, recursive=True)
         assert r.retcode == 0, r.error
         assert r.value

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -11,16 +11,3 @@ class TestTerraformCommandImport:
             assert 'Import does not generate resource configuration' not in r.value
         finally:
             cli.destroy()
-
-    def test_import_missing(self, cli: TerraformCommand):
-        cli.destroy()
-        try:
-            r = cli.import_resource('time_sleep.missing', '1s,')
-            assert r.retcode == 1, r.value
-
-            r = cli.import_resource('time_sleep.missing', '1s,', allow_missing_config=True)
-            assert r.retcode == 0, r.error
-            assert 'Import successful!' in r.value
-            assert 'Import does not generate resource configuration' in r.value
-        finally:
-            cli.destroy()

--- a/tests/consts.py
+++ b/tests/consts.py
@@ -3,3 +3,4 @@ import os
 ROOT = os.path.dirname(__file__)
 TF_DIR = os.path.join(ROOT, 'tf')
 TF_SLEEP_DIR = os.path.join(TF_DIR, 'sleep')
+TF_SLEEP2_DIR = os.path.join(TF_DIR, 'sleep2')

--- a/tests/tf/sleep2/main.tf
+++ b/tests/tf/sleep2/main.tf
@@ -1,0 +1,25 @@
+variable "sleep2_time1" {
+  type    = string
+  default = "1s"
+}
+
+variable "sleep2_time2" {
+  type    = string
+  default = "1s"
+}
+
+resource "time_sleep" "sleep2_wait1" {
+  create_duration = var.time1
+}
+
+resource "time_sleep" "sleep2_wait2" {
+  create_duration = var.time2
+}
+
+output "sleep2_wait1_id" {
+  value = time_sleep.wait1.id
+}
+
+output "sleep2_wait2_id" {
+  value = time_sleep.wait2.id
+}


### PR DESCRIPTION
- `fmt` supports multi dirs
- `force_unlock` removes allow_missing_config
- only python 3.7 and above are supported