### PR TITLE
Update terraform to 1.5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-20.04, windows-2019, macos-latest ]
         python-version: [ '3.7.9', '3.8.10', '3.9.13', '3.10.11', '3.11.5' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 
 | libterraform                                          | Terraform                                                   |
 |-------------------------------------------------------|-------------------------------------------------------------|
+| [0.6.0](https://pypi.org/project/libterraform/0.6.0/) | [1.5.7](https://github.com/hashicorp/terraform/tree/v1.5.7) |
 | [0.5.0](https://pypi.org/project/libterraform/0.5.0/) | [1.3.0](https://github.com/hashicorp/terraform/tree/v1.3.0) |
 | [0.4.0](https://pypi.org/project/libterraform/0.4.0/) | [1.2.2](https://github.com/hashicorp/terraform/tree/v1.2.2) |
 | [0.3.1](https://pypi.org/project/libterraform/0.3.1/) | [1.1.7](https://github.com/hashicorp/terraform/tree/v1.1.7) |
@@ -98,7 +99,7 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 If you want to develop this library, should first prepare the following environments:
 
 - [GoLang](https://go.dev/dl/) (Version 1.18+)
-- [Python](https://www.python.org/downloads/) (Version 3.7~3.10)
+- [Python](https://www.python.org/downloads/) (Version 3.7~3.11)
 - GCC
 
 Then, initialize git submodule:

--- a/libterraform/__init__.py
+++ b/libterraform/__init__.py
@@ -2,7 +2,7 @@ import os
 from ctypes import cdll, c_void_p
 from libterraform.common import WINDOWS
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 
 root = os.path.dirname(os.path.abspath(__file__))
 _lib_filename = 'libterraform.dll' if WINDOWS else 'libterraform.so'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libterraform"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python binding for Terraform."
 authors = ["Prodesire <wangbinxin001@126.com>"]
 license = "MIT"


### PR DESCRIPTION
Prepare a 0.6.0 release, building from the last MPL licensed terraform version 1.5.7.

Fixed test workflow failing on Windows.