### PR TITLE
Update terraform to 1.6.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Set up GoLang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '^1.21.5'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Set up GoLang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '^1.21.5'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 
 | libterraform                                          | Terraform                                                   |
 |-------------------------------------------------------|-------------------------------------------------------------|
+| [0.7.0](https://pypi.org/project/libterraform/0.7.0/) | [1.6.6](https://github.com/hashicorp/terraform/tree/v1.6.6) |
 | [0.6.0](https://pypi.org/project/libterraform/0.6.0/) | [1.5.7](https://github.com/hashicorp/terraform/tree/v1.5.7) |
 | [0.5.0](https://pypi.org/project/libterraform/0.5.0/) | [1.3.0](https://github.com/hashicorp/terraform/tree/v1.3.0) |
 | [0.4.0](https://pypi.org/project/libterraform/0.4.0/) | [1.2.2](https://github.com/hashicorp/terraform/tree/v1.2.2) |
@@ -98,7 +99,7 @@ dict_keys(['time_sleep.wait1', 'time_sleep.wait2'])
 
 If you want to develop this library, should first prepare the following environments:
 
-- [GoLang](https://go.dev/dl/) (Version 1.18+)
+- [GoLang](https://go.dev/dl/) (Version 1.21.5+)
 - [Python](https://www.python.org/downloads/) (Version 3.7~3.11)
 - GCC
 

--- a/build.py
+++ b/build.py
@@ -52,7 +52,8 @@ def build(setup_kwargs):
     try:
         print('      - Building libterraform')
         subprocess.check_call(
-            ['go', 'build', '-buildmode=c-shared', f'-o={lib_filename}', tf_package_name],
+            ['go', 'build', '-buildmode=c-shared', f'-o={lib_filename}',
+            "-ldflags", "-X github.com/hashicorp/terraform/version.dev=no", tf_package_name],
             cwd=terraform_dirname
         )
         shutil.move(lib_path, os.path.join(root, 'libterraform', lib_filename))

--- a/libterraform/__init__.py
+++ b/libterraform/__init__.py
@@ -2,7 +2,7 @@ import os
 from ctypes import cdll, c_void_p
 from libterraform.common import WINDOWS
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 
 root = os.path.dirname(os.path.abspath(__file__))
 _lib_filename = 'libterraform.dll' if WINDOWS else 'libterraform.so'

--- a/libterraform/cli.py
+++ b/libterraform/cli.py
@@ -1452,6 +1452,7 @@ class TerraformCommand:
     def test(
             self,
             check: bool = False,
+            vars: dict = None,
             no_color: bool = True,
             compact_warnings: bool = None,
             junit_xml: str = None,
@@ -1508,6 +1509,7 @@ class TerraformCommand:
         able to write but that were difficult to model in some way.
 
         :param check: Whether to check return code.
+        :param vars: Set variables in the root module of the configuration.
         :param no_color: True to output not contain any color.
         :param compact_warnings: Use a more compact representation for warnings, if
              this command produces only warnings and no errors.
@@ -1519,6 +1521,7 @@ class TerraformCommand:
         :param options: More command options.
         """
         options.update(
+            var=vars,
             no_color=flag(no_color),
             compact_warnings=flag(compact_warnings),
             junit_xml=junit_xml,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libterraform"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python binding for Terraform."
 authors = ["Prodesire <wangbinxin001@126.com>"]
 license = "MIT"

--- a/tests/cli/test_test.py
+++ b/tests/cli/test_test.py
@@ -1,9 +1,34 @@
+import os.path
+
 from libterraform import TerraformCommand
+from tests.consts import TF_SLEEP2_DIR
 
 
 class TestTerraformCommandTest:
     def test_test(self, cli: TerraformCommand):
         r = cli.test()
         assert r.retcode == 0, r.error
-        assert 'The "terraform test" command is experimental' in r.value
-        assert 'No tests defined' in r.error
+        assert "Success! 0 passed, 0 failed." in r.value
+        assert "".__eq__(r.error)
+
+    def test_test_run(self):
+        cwd = TF_SLEEP2_DIR
+        tf = os.path.join(cwd, ".terraform")
+
+        cli = TerraformCommand(cwd)
+        if not os.path.exists(tf):
+            cli.init()
+        r = cli.test()
+        assert r.retcode == 0, r.error
+        assert "Success! 1 passed, 0 failed." in r.value
+
+    def test_test_assertion_error(self):
+        cwd = TF_SLEEP2_DIR
+        tf = os.path.join(cwd, ".terraform")
+
+        cli = TerraformCommand(cwd)
+        if not os.path.exists(tf):
+            cli.init()
+        r = cli.test(vars={"sleep2_time1": "2s"})
+        assert r.retcode == 1
+        assert "libterraform test success!" in r.error

--- a/tests/tf/sleep2/main.tf
+++ b/tests/tf/sleep2/main.tf
@@ -9,17 +9,17 @@ variable "sleep2_time2" {
 }
 
 resource "time_sleep" "sleep2_wait1" {
-  create_duration = var.time1
+  create_duration = var.sleep2_time1
 }
 
 resource "time_sleep" "sleep2_wait2" {
-  create_duration = var.time2
+  create_duration = var.sleep2_time2
 }
 
 output "sleep2_wait1_id" {
-  value = time_sleep.wait1.id
+  value = time_sleep.sleep2_wait1.id
 }
 
 output "sleep2_wait2_id" {
-  value = time_sleep.wait2.id
+  value = time_sleep.sleep2_wait2.id
 }

--- a/tests/tf/sleep2/valid_sleep.tftest.hcl
+++ b/tests/tf/sleep2/valid_sleep.tftest.hcl
@@ -1,0 +1,17 @@
+variables {
+  sleep2_time2 = "2s"
+}
+
+run "valid_sleep_duration" {
+
+  assert {
+    condition     = time_sleep.sleep2_wait1.create_duration == "1s"
+    error_message = "libterraform test success!"
+  }
+
+  assert {
+    condition     = time_sleep.sleep2_wait2.create_duration == "2s"
+    error_message = "Duration did not match expected"
+  }
+
+}


### PR DESCRIPTION
Prepare a 0.7.0 release. Bumps terraform to 1.6.6. This is the most up to date version with OpenTofu compatibility.

Terraform's minimum go version is now 1.21.5.

Add tests for updated terraform test command.