### PR TITLE
Avoid parent-process chdir during Terraform commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@
 pip install libterraform
 ```
 
-> **Threading:** `TerraformCommand` can be called from multiple Python threads,
-> but Terraform CLI execution is serialized inside the shared library because
-> Terraform uses process-wide state. Use `TerraformPool` (or separate processes)
-> if you need truly parallel Terraform operations.
+> **Execution model:** `TerraformCommand` and `AsyncTerraformCommand` use
+> process-isolated execution by default, so Terraform's process-wide state does
+> not leak into the caller process. Use `backend="thread"` only when you
+> explicitly want the current-process backend. Use `TerraformPool` when you want
+> to reuse worker processes or run independent Terraform operations in parallel.
 
 ## Usage
 
@@ -56,8 +57,8 @@ cli = AsyncTerraformCommand("path/to/module")
 await cli.validate(check=True)
 ```
 
-Use `TerraformPool` to run Terraform commands in parallel across worker
-processes:
+Use `TerraformPool` to reuse worker processes and run Terraform commands in
+parallel:
 
 ```python
 from libterraform import TerraformPool

--- a/docs/en/alternatives.md
+++ b/docs/en/alternatives.md
@@ -23,7 +23,7 @@ binary.
 
 | Tool | Integration model | Best fit | Tradeoffs |
 |---|---|---|---|
-| `libterraform` | Bundled Terraform shared library loaded by Python | Python automation, control planes, internal platforms, and tools that need Terraform available without installing a separate binary | Wheels are larger; each release line embeds one Terraform version line; Terraform CLI execution is serialized inside one Python process |
+| `libterraform` | Bundled Terraform shared library loaded by Python | Python automation, control planes, internal platforms, and tools that need Terraform available without installing a separate binary | Wheels are larger; each release line embeds one Terraform version line; default process isolation starts worker processes |
 | `python-terraform` | Wrapper around an installed `terraform` CLI | Existing scripts that already have Terraform installed and only need a light command wrapper | Depends on an external binary; returns raw process output; the upstream project has had long maintenance gaps |
 | TofuPy | Wrapper around installed OpenTofu or Terraform binaries | Teams that want a modern Python wrapper and need OpenTofu support | Still requires `tofu` or `terraform` on `PATH`; it wraps the executable rather than embedding Terraform into the Python package |
 | Direct `subprocess` | Your code shells out to `terraform` directly | Small scripts, CI jobs, and cases where explicit process control is enough | You own argument conversion, JSON parsing, error handling, streaming, cancellation, and binary management |
@@ -46,8 +46,8 @@ runtime capability of the application:
   `TerraformConfig`, without invoking a CLI command.
 - Async applications need awaitable Terraform calls while keeping the event loop
   responsive.
-- Independent module operations need process-isolated parallelism through
-  `TerraformPool`.
+- Independent module operations need reusable process workers or parallelism
+  through `TerraformPool`.
 
 ## When Another Option Fits Better
 
@@ -114,8 +114,8 @@ From `python-terraform` or `subprocess`, the main changes are:
 - Use `check=True` when failures should raise `TerraformCommandError`.
 - Use `json=False` when you need Terraform's plain text output instead of parsed
   structured values.
-- Use `TerraformPool` for true parallel execution across independent module
-  directories.
+- Use `TerraformPool` to reuse worker processes or run independent module
+  directories in parallel.
 
 ```python
 from libterraform import TerraformCommand

--- a/docs/en/api/async-terraform-command.md
+++ b/docs/en/api/async-terraform-command.md
@@ -8,22 +8,25 @@ from libterraform import AsyncTerraformCommand
 
 `AsyncTerraformCommand` provides asyncio-compatible access to
 `TerraformCommand`. It mirrors the synchronous command methods and runs the
-blocking Terraform call in a worker thread, so callers can `await` Terraform
-operations without blocking the event loop.
+blocking Terraform call away from the event-loop thread, so callers can `await`
+Terraform operations without blocking the event loop.
 
 ## Execution Model
 
-By default `AsyncTerraformCommand` runs the blocking call in a worker thread, so
-it does not make Terraform CLI execution parallel inside one Python process.
-Terraform still uses process-wide state, so the shared library serializes CLI
-execution. Pass a [`TerraformPool`](terraform-pool.md) as `pool` to run commands
-in worker processes when you need true parallel Terraform operations.
+By default `AsyncTerraformCommand` uses `TerraformCommand`'s process backend. The
+Terraform CLI call runs in a controlled worker process, so Terraform's
+process-wide state does not leak into the event-loop process. Use
+`backend="thread"` only when you explicitly want the current-process backend.
+Pass a [`TerraformPool`](terraform-pool.md) as `pool` when you want to reuse
+worker processes or run independent Terraform operations in parallel.
 
-If a coroutine is cancelled, the awaiting task is cancelled, but the underlying
-worker thread is not terminated directly by this API. `AsyncTerraformCommand` sends a
-cooperative cancellation request to Terraform's shutdown channel and then
-re-raises `asyncio.CancelledError`. Terraform or a provider may still take some
-time to return from its own shutdown path.
+If a coroutine is cancelled, the awaiting task is cancelled and the active
+backend is asked to stop the Terraform run. With the default process backend the
+worker process is interrupted. With `backend="thread"`, the worker thread is not
+terminated directly; `AsyncTerraformCommand` sends a cooperative cancellation
+request to Terraform's shutdown channel and then re-raises
+`asyncio.CancelledError`. Terraform or a provider may still take some time to
+return from its own shutdown path.
 
 ## Usage
 
@@ -43,8 +46,9 @@ plan = await cli.plan(check=True)
 retcode, stdout, stderr = await AsyncTerraformCommand.run("version")
 ```
 
-Pass an executor when you need to integrate with an application-owned thread
-pool:
+Pass an executor when you need to integrate the awaitable wrapper with an
+application-owned thread pool. This controls where the blocking Python wrapper
+waits; it does not switch Terraform execution to the thread backend:
 
 ```python
 from concurrent.futures import ThreadPoolExecutor
@@ -52,6 +56,13 @@ from concurrent.futures import ThreadPoolExecutor
 with ThreadPoolExecutor(max_workers=1) as executor:
     cli = AsyncTerraformCommand("path/to/terraform/module", executor=executor)
     validation = await cli.validate(check=True)
+```
+
+To opt in to the current-process backend, pass `backend="thread"`:
+
+```python
+cli = AsyncTerraformCommand("path/to/terraform/module", backend="thread")
+validation = await cli.validate(check=True)
 ```
 
 Pass a `TerraformPool` as `pool` to await commands that run in worker processes,
@@ -79,10 +90,10 @@ task = asyncio.create_task(cli.apply(auto_approve=True))
 task.cancel()
 ```
 
-This asks Terraform to stop through its normal interrupt handling. With the
-default thread backend it is not a direct termination of the worker thread; with
-a `pool` backend the request is delivered to the worker process running the
-command.
+This asks Terraform to stop through the active backend. With the default process
+backend the worker process is interrupted; with `backend="thread"` it is not a
+direct termination of the worker thread; with a `pool` backend the request is
+delivered to the worker process running the command.
 
 ::: libterraform.async_cli.AsyncTerraformCommand
     options:

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -5,9 +5,11 @@ The public package exports:
 ```python
 from libterraform import (
     AsyncTerraformCommand,
+    ProcessTerraformCommand,
     TerraformCommand,
     TerraformConfig,
     TerraformPool,
+    ThreadTerraformCommand,
 )
 ```
 
@@ -15,9 +17,9 @@ Exception classes are available from `libterraform.exceptions`.
 
 ## Pages
 
-- [TerraformCommand](terraform-command.md) covers command execution,
-  `CommandResult`, option conversion, JSON parsing, and Terraform CLI helper
-  methods.
+- [TerraformCommand](terraform-command.md) covers command execution, process and
+  thread backends, `CommandResult`, option conversion, JSON parsing, and
+  Terraform CLI helper methods.
 - [AsyncTerraformCommand](async-terraform-command.md) covers asyncio-compatible
   command execution for asyncio applications.
 - [TerraformPool](terraform-pool.md) covers process-based parallel execution of

--- a/docs/en/api/terraform-command.md
+++ b/docs/en/api/terraform-command.md
@@ -8,12 +8,22 @@ from libterraform import TerraformCommand
 
 Most high-level methods return a `CommandResult`.
 
-## Threading
+## Execution Backend
 
-`TerraformCommand` can be called from multiple Python threads. Calls are
-thread-safe, but Terraform CLI execution is serialized inside the shared
-library because Terraform uses process-wide state. Use separate processes for
-true parallel Terraform operations.
+`TerraformCommand` uses the `"process"` backend by default. Each Terraform CLI
+call runs in a controlled worker process, so Terraform's process-wide state
+(`os.chdir`, stdio, signal handling, plugin cleanup) does not leak into the
+caller process.
+
+Use `TerraformCommand(cwd, backend="thread")` or
+`TerraformCommand.run("version", backend="thread")` to opt in to the
+current-process backend. The thread backend keeps the previous low-overhead path
+and restores global state after each call, but other Python code in the same
+process can observe Terraform's temporary working-directory changes while a
+command is running.
+
+Use `TerraformPool` when you want to reuse worker processes or run independent
+module operations in parallel.
 
 ## CommandResult
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -31,7 +31,7 @@ parsing Terraform configuration directories.
 
 | libterraform | Terraform |
 |---|---|
-| [0.15.2](https://pypi.org/project/libterraform/0.15.2/) | [1.15.5](https://github.com/hashicorp/terraform/tree/v1.15.5) |
+| [0.15.3](https://pypi.org/project/libterraform/0.15.3/) | [1.15.5](https://github.com/hashicorp/terraform/tree/v1.15.5) |
 | [0.14.0](https://pypi.org/project/libterraform/0.14.0/) | [1.14.9](https://github.com/hashicorp/terraform/tree/v1.14.9) |
 | [0.13.0](https://pypi.org/project/libterraform/0.13.0/) | [1.13.5](https://github.com/hashicorp/terraform/tree/v1.13.5) |
 | [0.12.0](https://pypi.org/project/libterraform/0.12.0/) | [1.12.2](https://github.com/hashicorp/terraform/tree/v1.12.2) |
@@ -47,15 +47,17 @@ parsing Terraform configuration directories.
 
 ## Runtime Constraints
 
-`TerraformCommand` is safe to call from multiple Python threads, but Terraform
-CLI execution is serialized inside the shared library. Terraform still uses
-process-wide state such as the current working directory, stdio, checkpoint
-state, and plugin client cleanup, so true parallel Terraform operations require
-separate processes.
+`TerraformCommand` and `AsyncTerraformCommand` use process-isolated execution by
+default. Terraform still uses process-wide state such as the current working
+directory, stdio, checkpoint state, and plugin client cleanup, so running the CLI
+in a controlled worker process prevents that state from leaking into the caller
+process.
 
-`AsyncTerraformCommand` has the same Terraform execution constraint. It makes
-the synchronous API awaitable for asyncio applications, but it does not make
-Terraform CLI execution parallel inside one Python process.
+Use `backend="thread"` only when you explicitly want the current-process backend.
+That path is lower overhead and restores global state after each call, but other
+Python code in the same process can observe Terraform's temporary global-state
+changes while a command is running. Use `TerraformPool` to reuse worker processes
+or run independent Terraform operations in parallel.
 
 Terraform operations can still affect real infrastructure, so use `apply`,
 `destroy`, state commands, imports, and tests with the same caution as the

--- a/docs/en/parallel-execution.md
+++ b/docs/en/parallel-execution.md
@@ -1,18 +1,17 @@
 # Parallel Execution
 
-`TerraformCommand` is safe to call from multiple Python threads, but Terraform
-CLI execution is serialized inside one Python process: Terraform reuses
-process-wide state (working directory, stdio, plugin clients, signal handling),
-so the shared library runs one command at a time. `AsyncTerraformCommand` keeps
-an asyncio event loop responsive, but it does not make Terraform itself run in
-parallel inside that process either.
+`TerraformCommand` and `AsyncTerraformCommand` use process-isolated execution by
+default because Terraform reuses process-wide state (working directory, stdio,
+plugin clients, signal handling). That default prevents Terraform's temporary
+global-state changes from leaking into the caller process.
 
-`TerraformPool` is the built-in way to get true parallel Terraform operations. It
-owns a `ProcessPoolExecutor` and runs each command in its own worker process, so
-independent module operations run at the same time. Each worker imports
-`libterraform`, builds its own `TerraformCommand`, and runs one command against
-one module directory; command results and `check=True` errors come back to the
-parent process unchanged.
+Use `backend="thread"` only when you knowingly want Terraform to run inside one Python process with the caller.
+
+`TerraformPool` is the built-in way to reuse worker processes and get true parallel Terraform operations. It owns a `ProcessPoolExecutor` and runs each
+command in its own worker process, so independent module operations run at the
+same time. Each worker imports `libterraform`, builds its own thread-backend
+`TerraformCommand`, and runs one command against one module directory; command
+results and `check=True` errors come back to the parent process unchanged.
 
 ## Before you start
 
@@ -139,9 +138,9 @@ See [TerraformPool](api/terraform-pool.md) for the full API.
 
 ### Stay responsive on the event loop
 
-By default `AsyncTerraformCommand` runs the blocking call in a worker thread. That
-keeps the event loop responsive, but Terraform CLI execution is still serialized
-inside the process:
+By default `AsyncTerraformCommand` runs the Terraform call in a worker process.
+That keeps the event loop responsive and prevents Terraform's process-wide state
+from leaking into the event-loop process:
 
 ```python
 from libterraform import AsyncTerraformCommand
@@ -152,10 +151,11 @@ validation = await cli.validate(check=True)
 
 ### Run commands in parallel with a pool
 
-To combine asyncio with true parallelism, pass a `TerraformPool` as the `pool`
-backend. Awaited commands then run in the pool's worker processes, so awaiting
-several of them concurrently gives genuine parallel Terraform execution. The same
-`__main__` guard applies, and the async entry point is `asyncio.run(main())`:
+To amortize worker startup and combine asyncio with true parallelism, pass a
+`TerraformPool` as the `pool` backend. Awaited commands then run in the pool's
+worker processes, so awaiting several of them concurrently gives genuine
+parallel Terraform execution. The same `__main__` guard applies, and the async
+entry point is `asyncio.run(main())`:
 
 ```python
 import asyncio
@@ -190,10 +190,10 @@ with TerraformPool(max_workers=4) as pool:
 
 ### Cancel an awaited command
 
-Cancelling the awaiting task requests cooperative cancellation for the run. With
-the default thread backend the worker thread is not terminated directly; with a
-`pool` backend the request is delivered to the worker process running the
-command:
+Cancelling the awaiting task requests cancellation for the run. With the default
+process backend the worker process is interrupted; with `backend="thread"` the
+worker thread is not terminated directly; with a `pool` backend the request is
+delivered to the worker process running the command:
 
 ```python
 task = asyncio.create_task(cli.apply(auto_approve=True))

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -121,13 +121,13 @@ cli = AsyncTerraformCommand(module_dir)
 validation = await cli.validate(check=True)
 ```
 
-By default the call runs in a worker thread, so Terraform CLI execution is still
-serialized inside the shared library. Cancelling the coroutine requests
-Terraform's cooperative shutdown path; it does not terminate the worker thread
-directly.
+By default the Terraform call runs in a worker process, so Terraform's
+process-wide state does not leak into the event-loop process. Use
+`backend="thread"` only when you explicitly want the current-process backend.
+Cancelling the coroutine interrupts the worker process for the default backend.
 
-To actually run Terraform commands at the same time — across modules, with sync
-or async APIs — see [Parallel Execution](parallel-execution.md), which covers
-`TerraformPool` and running `AsyncTerraformCommand` on a process pool.
+To reuse worker processes or run Terraform commands at the same time — across
+modules, with sync or async APIs — see [Parallel Execution](parallel-execution.md),
+which covers `TerraformPool`.
 
 See the [API Reference](api/index.md) for the generated interface documentation.

--- a/docs/zh/alternatives.md
+++ b/docs/zh/alternatives.md
@@ -19,7 +19,7 @@ Python 生态里有多种方式可以和 Terraform 协作。它们解决的问�
 
 | 工具 | 集成模型 | 适合场景 | 取舍 |
 |---|---|---|---|
-| `libterraform` | Python 加载内置的 Terraform 共享库 | Python 自动化、控制面、内部平台，以及不希望额外安装 Terraform binary 的工具 | wheel 更大；每个发布线内置一个 Terraform 版本线；同一 Python 进程内 Terraform CLI 执行会串行化 |
+| `libterraform` | Python 加载内置的 Terraform 共享库 | Python 自动化、控制面、内部平台，以及不希望额外安装 Terraform binary 的工具 | wheel 更大；每个发布线内置一个 Terraform 版本线；默认进程隔离会启动 worker 进程 |
 | `python-terraform` | 封装已安装的 `terraform` CLI | 已经安装 Terraform、只需要轻量命令封装的既有脚本 | 依赖外部 binary；主要返回进程输出；上游项目长期存在维护间隔 |
 | TofuPy | 封装已安装的 OpenTofu 或 Terraform binary | 希望使用现代 Python wrapper，并且需要 OpenTofu 支持的团队 | 仍要求 `tofu` 或 `terraform` 在 `PATH` 中；它封装的是可执行文件，而不是把 Terraform 嵌入 Python 包 |
 | 直接 `subprocess` | 业务代码直接启动 `terraform` 进程 | 小脚本、CI job，或显式进程控制已经足够的场景 | 参数转换、JSON 解析、错误处理、流式输出、取消和 binary 管理都需要自己维护 |
@@ -38,7 +38,7 @@ Python 生态里有多种方式可以和 Terraform 协作。它们解决的问�
   `stdout`、`stderr` 和退出码。
 - 工具需要通过 `TerraformConfig` 加载 Terraform 配置目录，而不执行 CLI 命令。
 - asyncio 应用需要可 `await` 的 Terraform 调用，同时保持 event loop 响应。
-- 独立模块操作需要通过 `TerraformPool` 做进程隔离的并行执行。
+- 独立模块操作需要通过 `TerraformPool` 复用 worker 进程或并行执行。
 
 ## 什么时候其他方案更合适
 
@@ -91,7 +91,7 @@ Terraform 版本线。如果应用需要其他 Terraform 版本线，请安装�
 - Terraform flag 通过 Python 关键字参数传入，CLI 中的 hyphen 使用 underscore。
 - 失败时希望抛出 `TerraformCommandError`，使用 `check=True`。
 - 需要 Terraform 原始文本输出时，使用 `json=False`；否则可以使用解析后的结构化值。
-- 对独立模块目录做真正并行执行时，使用 `TerraformPool`。
+- 需要复用 worker 进程或让独立模块目录并行执行时，使用 `TerraformPool`。
 
 ```python
 from libterraform import TerraformCommand

--- a/docs/zh/api/async-terraform-command.md
+++ b/docs/zh/api/async-terraform-command.md
@@ -7,20 +7,23 @@ from libterraform import AsyncTerraformCommand
 ```
 
 `AsyncTerraformCommand` 为 `TerraformCommand` 提供 asyncio 兼容 API。它镜像同步命令
-方法，并把阻塞的 Terraform 调用放到 worker thread 中执行，因此调用方可以
-`await` Terraform 操作，而不会阻塞 event loop。
+方法，并把阻塞的 Terraform 调用移出 event-loop thread，因此调用方可以 `await`
+Terraform 操作，而不会阻塞 event loop。
 
 ## 执行模型
 
-`AsyncTerraformCommand` 默认把阻塞调用放到 worker thread 中执行，因此不会让同一个
-Python 进程内的 Terraform CLI 调用变成真正并行。Terraform 仍然使用进程级全局状态，
-因此共享库内部仍会串行执行 CLI 调用。如需真正并行的 Terraform 操作，可传入
-[`TerraformPool`](terraform-pool.md) 作为 `pool`，让命令在 worker 进程中执行。
+`AsyncTerraformCommand` 默认使用 `TerraformCommand` 的 process backend。Terraform CLI
+调用会在受控 worker 进程中执行，因此 Terraform 的进程级全局状态不会泄漏到
+event-loop 进程。只有在明确需要当前进程后端时，才使用 `backend="thread"`。如果需要
+复用 worker 进程或让独立 Terraform 操作真正并行执行，可传入
+[`TerraformPool`](terraform-pool.md) 作为 `pool`。
 
-如果 coroutine 被取消，等待中的 task 会被取消，但该 API 不会直接终止已经在线程
-中运行的 Terraform 调用。`AsyncTerraformCommand` 会向 Terraform 的 shutdown channel 发送协作式取消
-请求，然后重新抛出 `asyncio.CancelledError`。Terraform 或 provider 仍可能需要一些
-时间从自己的 shutdown 流程中返回。
+如果 coroutine 被取消，等待中的 task 会被取消，并且当前 backend 会被请求停止该
+Terraform run。使用默认 process backend 时，worker 进程会被中断。使用
+`backend="thread"` 时，该 API 不会直接终止 worker thread；`AsyncTerraformCommand`
+会向 Terraform 的 shutdown channel 发送协作式取消请求，然后重新抛出
+`asyncio.CancelledError`。Terraform 或 provider 仍可能需要一些时间从自己的 shutdown
+流程中返回。
 
 ## 使用
 
@@ -39,7 +42,8 @@ plan = await cli.plan(check=True)
 retcode, stdout, stderr = await AsyncTerraformCommand.run("version")
 ```
 
-如果应用需要使用自己的线程池，可以传入 executor：
+如果应用需要使用自己的线程池，可以传入 executor。它只控制阻塞 Python wrapper 在哪里
+等待，不会把 Terraform 执行切换为 thread backend：
 
 ```python
 from concurrent.futures import ThreadPoolExecutor
@@ -47,6 +51,13 @@ from concurrent.futures import ThreadPoolExecutor
 with ThreadPoolExecutor(max_workers=1) as executor:
     cli = AsyncTerraformCommand("path/to/terraform/module", executor=executor)
     validation = await cli.validate(check=True)
+```
+
+如果要显式使用当前进程后端，请传入 `backend="thread"`：
+
+```python
+cli = AsyncTerraformCommand("path/to/terraform/module", backend="thread")
+validation = await cli.validate(check=True)
 ```
 
 传入 `TerraformPool` 作为 `pool`，即可等待在 worker 进程中执行的命令，从而获得真正
@@ -73,8 +84,9 @@ task = asyncio.create_task(cli.apply(auto_approve=True))
 task.cancel()
 ```
 
-这会请求 Terraform 通过正常 interrupt 处理停止。使用默认线程后端时，它不会直接终止
-worker thread；使用 `pool` 后端时，该请求会投递到运行该命令的 worker 进程。
+这会请求当前 backend 停止 Terraform。使用默认 process backend 时，worker 进程会被
+中断；使用 `backend="thread"` 时，它不会直接终止 worker thread；使用 `pool` 后端时，
+该请求会投递到运行该命令的 worker 进程。
 
 ::: libterraform.async_cli.AsyncTerraformCommand
     options:

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -5,9 +5,11 @@
 ```python
 from libterraform import (
     AsyncTerraformCommand,
+    ProcessTerraformCommand,
     TerraformCommand,
     TerraformConfig,
     TerraformPool,
+    ThreadTerraformCommand,
 )
 ```
 
@@ -15,8 +17,8 @@ from libterraform import (
 
 ## 页面
 
-- [TerraformCommand](terraform-command.md)：命令执行、`CommandResult`、
-  参数转换、JSON 解析和 Terraform CLI 辅助方法。
+- [TerraformCommand](terraform-command.md)：命令执行、process/thread backend、
+  `CommandResult`、参数转换、JSON 解析和 Terraform CLI 辅助方法。
 - [AsyncTerraformCommand](async-terraform-command.md)：面向 asyncio 应用的异步
   兼容命令执行。
 - [TerraformPool](terraform-pool.md)：基于多进程的 Terraform 命令并行执行。

--- a/docs/zh/api/terraform-command.md
+++ b/docs/zh/api/terraform-command.md
@@ -10,11 +10,18 @@ from libterraform import TerraformCommand
 方法。构造时可传入 `cwd` 作为默认 Terraform 工作目录。多数高层方法会返回
 `CommandResult`。
 
-## 线程说明
+## 执行 backend
 
-`TerraformCommand` 可以被多个 Python 线程调用。调用本身是线程安全的，但由于
-Terraform 使用进程级全局状态，共享库内部会串行执行 Terraform CLI。如需真正并行的
-Terraform 操作，请使用多个进程隔离。
+`TerraformCommand` 默认使用 `"process"` backend。每次 Terraform CLI 调用都会在受控
+worker 进程中执行，因此 Terraform 的进程级全局状态（`os.chdir`、stdio、信号处理、
+plugin 清理）不会泄漏到调用方进程。
+
+如果明确需要当前进程后端，可以使用 `TerraformCommand(cwd, backend="thread")` 或
+`TerraformCommand.run("version", backend="thread")`。thread backend 保留原来的低开销
+路径，并在每次调用结束后恢复全局状态；但命令运行期间，同一 Python 进程中的其他代码
+仍可能观察到 Terraform 临时切换后的工作目录。
+
+如果需要复用 worker 进程或让独立模块真正并行执行，请使用 `TerraformPool`。
 
 ## CommandResult
 
@@ -80,6 +87,7 @@ Terraform 操作，请使用多个进程隔离。
 | `chdir` | | 执行子命令前切换到指定目录，对应 Terraform 的 `-chdir`。 | `None` |
 | `check` | `bool` | 是否在异常返回码时抛出 `TerraformCommandError`。 | `False` |
 | `json` | | 是否追加 `-json`。仅部分命令支持此参数。 | `False` |
+| `backend` | `str` | 执行 backend。默认为 `"process"`；设置为 `"thread"` 可使用当前进程后端。 | `"process"` |
 
 ::: libterraform.cli.TerraformCommand.version
     options:

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -30,7 +30,7 @@
 
 | libterraform | Terraform |
 |---|---|
-| [0.15.2](https://pypi.org/project/libterraform/0.15.2/) | [1.15.5](https://github.com/hashicorp/terraform/tree/v1.15.5) |
+| [0.15.3](https://pypi.org/project/libterraform/0.15.3/) | [1.15.5](https://github.com/hashicorp/terraform/tree/v1.15.5) |
 | [0.14.0](https://pypi.org/project/libterraform/0.14.0/) | [1.14.9](https://github.com/hashicorp/terraform/tree/v1.14.9) |
 | [0.13.0](https://pypi.org/project/libterraform/0.13.0/) | [1.13.5](https://github.com/hashicorp/terraform/tree/v1.13.5) |
 | [0.12.0](https://pypi.org/project/libterraform/0.12.0/) | [1.12.2](https://github.com/hashicorp/terraform/tree/v1.12.2) |
@@ -46,13 +46,14 @@
 
 ## 运行约束
 
-`TerraformCommand` 可以被多个 Python 线程安全调用，但 Terraform CLI 会在共享库
-内部串行执行。Terraform 仍使用当前工作目录、stdio、checkpoint 状态和 plugin
-client 清理等进程级全局状态，因此真正并行的 Terraform 操作需要使用多个进程隔离。
+`TerraformCommand` 和 `AsyncTerraformCommand` 默认使用进程隔离执行。Terraform 仍使用
+当前工作目录、stdio、checkpoint 状态和 plugin client 清理等进程级全局状态，因此把
+CLI 放到受控 worker 进程中运行，可以避免这些状态泄漏到调用方进程。
 
-`AsyncTerraformCommand` 也遵循同样的 Terraform 执行约束。它让同步 API 可以在
-asyncio 应用中被 `await`，但不会让同一个 Python 进程内的 Terraform CLI 执行变成
-真正并行。
+只有在明确需要当前进程后端时，才使用 `backend="thread"`。该路径开销更低，并会在每次
+调用结束后恢复全局状态；但命令运行期间，同一 Python 进程中的其他代码仍可能观察到
+Terraform 临时修改后的全局状态。如果需要复用 worker 进程或让独立 Terraform 操作真正
+并行执行，请使用 `TerraformPool`。
 
 Terraform 操作仍可能影响真实基础设施，因此执行 `apply`、`destroy`、状态命令、
 导入和测试时，应保持与直接使用 Terraform CLI 相同的谨慎程度。

--- a/docs/zh/parallel-execution.md
+++ b/docs/zh/parallel-execution.md
@@ -1,15 +1,16 @@
 # 并行执行
 
-`TerraformCommand` 可以被多个 Python 线程安全调用，但在单个 Python 进程内，
-Terraform CLI 执行会被串行化：Terraform 复用进程级全局状态（工作目录、stdio、plugin
-客户端、信号处理），因此共享库一次只能执行一条命令。`AsyncTerraformCommand` 能让
-asyncio event loop 保持响应，但同样不会让 Terraform 在该进程内真正并行执行。
+`TerraformCommand` 和 `AsyncTerraformCommand` 默认使用进程隔离执行，因为 Terraform
+复用进程级全局状态（工作目录、stdio、plugin 客户端、信号处理）。默认 backend 可以
+避免 Terraform 临时修改的全局状态泄漏到调用方进程。
 
-`TerraformPool` 是内置的、用于获得真正并行 Terraform 操作的方式。它持有一个
-`ProcessPoolExecutor`，让每条命令运行在独立的 worker 进程中，从而让相互独立的模块
-操作同时执行。每个 worker 都会导入 `libterraform`，构建自己的 `TerraformCommand`，并
-针对单个模块目录运行一条命令；命令结果以及 `check=True` 抛出的错误会原样返回给
-父进程。
+只有在明确希望 Terraform 与调用方运行在单个 Python 进程中时，才使用 `backend="thread"`。
+
+`TerraformPool` 是内置的、用于复用 worker 进程并获得真正并行 Terraform 操作的方式。
+它持有一个 `ProcessPoolExecutor`，让每条命令运行在独立的 worker 进程中，从而让相互
+独立的模块操作同时执行。每个 worker 都会导入 `libterraform`，构建自己的 thread-backend
+`TerraformCommand`，并针对单个模块目录运行一条命令；命令结果以及 `check=True` 抛出的
+错误会原样返回给父进程。
 
 ## 准备
 
@@ -128,8 +129,8 @@ with TerraformPool(max_workers=2) as pool:
 
 ### 保持 event loop 响应
 
-`AsyncTerraformCommand` 默认把阻塞调用放到 worker thread 中执行。这能让 event loop
-保持响应，但 Terraform CLI 执行在进程内仍是串行的：
+`AsyncTerraformCommand` 默认把 Terraform 调用放到 worker 进程中执行。这能让 event
+loop 保持响应，并避免 Terraform 的进程级全局状态泄漏到 event-loop 进程：
 
 ```python
 from libterraform import AsyncTerraformCommand
@@ -140,9 +141,10 @@ validation = await cli.validate(check=True)
 
 ### 用进程池并行执行命令
 
-要在 asyncio 中同时获得真正并行，可传入 `TerraformPool` 作为 `pool` 后端。此时被等待
-的命令会在 pool 的 worker 进程中执行，因此并发等待多条命令即可获得真正并行的
-Terraform 执行。同样需要 `__main__` 保护，异步入口为 `asyncio.run(main())`：
+要摊薄 worker 启动成本并在 asyncio 中获得真正并行，可传入 `TerraformPool` 作为
+`pool` 后端。此时被等待的命令会在 pool 的 worker 进程中执行，因此并发等待多条命令
+即可获得真正并行的 Terraform 执行。同样需要 `__main__` 保护，异步入口为
+`asyncio.run(main())`：
 
 ```python
 import asyncio
@@ -177,8 +179,9 @@ with TerraformPool(max_workers=4) as pool:
 
 ### 取消等待中的命令
 
-取消等待中的 task 会为该 run 请求协作式取消。使用默认线程后端时，不会直接终止
-worker thread；使用 `pool` 后端时，该请求会投递到运行该命令的 worker 进程：
+取消等待中的 task 会为该 run 请求取消。使用默认 process backend 时，worker 进程会被
+中断；使用 `backend="thread"` 时，不会直接终止 worker thread；使用 `pool` 后端时，
+该请求会投递到运行该命令的 worker 进程：
 
 ```python
 task = asyncio.create_task(cli.apply(auto_approve=True))

--- a/docs/zh/quickstart.md
+++ b/docs/zh/quickstart.md
@@ -117,12 +117,11 @@ cli = AsyncTerraformCommand(module_dir)
 validation = await cli.validate(check=True)
 ```
 
-默认情况下调用运行在 worker thread 中，因此 Terraform CLI 执行在共享库内部仍是
-串行的。取消 coroutine 会请求 Terraform 进入协作式 shutdown 流程，但不会直接终止
-worker thread。
+默认情况下 Terraform 调用运行在 worker 进程中，因此 Terraform 的进程级全局状态不会
+泄漏到 event-loop 进程。只有在明确需要当前进程后端时，才使用 `backend="thread"`。
+使用默认 backend 时，取消 coroutine 会中断 worker 进程。
 
-要让 Terraform 命令真正同时执行——跨多个模块、同步或异步——请见
-[并行执行](parallel-execution.md)，其中介绍了 `TerraformPool` 以及如何让
-`AsyncTerraformCommand` 运行在进程池上。
+如果需要复用 worker 进程，或让 Terraform 命令跨多个模块真正同时执行（同步或异步），
+请见[并行执行](parallel-execution.md)，其中介绍了 `TerraformPool`。
 
 完整接口见 [API 参考](api/index.md)。

--- a/release-matrix.json
+++ b/release-matrix.json
@@ -79,7 +79,7 @@
     },
     {
       "libterraform_minor": "0.15",
-      "libterraform_version": "0.15.2",
+      "libterraform_version": "0.15.3",
       "terraform_minor": "1.15",
       "terraform_version": "1.15.5",
       "go_plugin_version": "1.7.0",

--- a/src/libterraform/__init__.py
+++ b/src/libterraform/__init__.py
@@ -3,7 +3,7 @@ from ctypes import c_void_p, cdll
 
 from libterraform.common import WINDOWS
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"
 
 root = os.path.dirname(os.path.abspath(__file__))
 _lib_filename = "libterraform.dll" if WINDOWS else "libterraform.so"
@@ -17,8 +17,10 @@ from .cli import (  # noqa: E402
     ApplyResult,
     CommandResult,
     PlanResult,
+    ProcessTerraformCommand,
     TerraformCommand,
     TerraformStream,
+    ThreadTerraformCommand,
 )
 from .async_cli import AsyncTerraformCommand  # noqa: E402
 from .config import TerraformConfig  # noqa: E402
@@ -32,9 +34,11 @@ __all__ = [
     "CommandResult",
     "OutputChange",
     "PlanResult",
+    "ProcessTerraformCommand",
     "ResourceChange",
     "TerraformCommand",
     "TerraformConfig",
     "TerraformPool",
     "TerraformStream",
+    "ThreadTerraformCommand",
 ]

--- a/src/libterraform/_process_worker.py
+++ b/src/libterraform/_process_worker.py
@@ -1,0 +1,54 @@
+"""Private subprocess entry point for process-isolated Terraform execution."""
+
+import pickle
+import sys
+
+from libterraform.cli import _invoke_cli, _run_argv_in_process
+
+
+def _read_payload():
+    return pickle.loads(sys.stdin.buffer.read())
+
+
+def _run_command(response_path):
+    payload = _read_payload()
+    try:
+        response = ("ok", _run_argv_in_process(payload["argv"], check=False))
+    except BaseException as exc:
+        response = ("error", exc)
+    with open(response_path, "wb") as f:
+        pickle.dump(response, f, protocol=pickle.HIGHEST_PROTOCOL)
+    return 0
+
+
+def _stream_command(run_id):
+    payload = _read_payload()
+    return _invoke_cli(
+        payload["argv"],
+        sys.stdout.fileno(),
+        sys.stderr.fileno(),
+        run_id,
+    )
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: python -m libterraform._process_worker MODE ...")
+    mode = sys.argv[1]
+    if mode == "run":
+        if len(sys.argv) != 3:
+            raise SystemExit(
+                "usage: python -m libterraform._process_worker run RESPONSE"
+            )
+        return _run_command(sys.argv[2])
+    if mode == "stream":
+        if len(sys.argv) != 3:
+            raise SystemExit(
+                "usage: python -m libterraform._process_worker stream RUN_ID"
+            )
+        return _stream_command(sys.argv[2])
+    raise SystemExit(f"unknown libterraform worker mode: {mode}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/libterraform/async_cli.py
+++ b/src/libterraform/async_cli.py
@@ -22,16 +22,17 @@ class AsyncTerraformCommand:
     This class mirrors `TerraformCommand` and awaits the
     Terraform call without blocking the event loop.
 
-    By default the synchronous call runs in a worker thread, so Terraform CLI
-    execution is still serialized inside the shared library because Terraform
-    uses process-wide state. Pass a `TerraformPool` as
-    ``pool`` to run commands in worker processes instead, which gives true
-    parallel Terraform execution.
+    By default the synchronous call uses process-isolated execution so Terraform's
+    process-wide state does not leak into the caller process. Use
+    ``backend="thread"`` to run through the current process, or pass a
+    `TerraformPool` as ``pool`` to reuse worker processes for true parallel
+    Terraform execution.
 
-    Cancelling the awaiting coroutine requests cooperative cancellation for the
-    corresponding Terraform run. With a thread backend the worker thread is not
-    terminated directly; with a process pool the owning worker is asked to
-    interrupt Terraform through its normal shutdown handling.
+    Cancelling the awaiting coroutine requests cancellation for the corresponding
+    Terraform run. With the process backend the worker process is interrupted;
+    with a thread backend the worker thread is not terminated directly; with a
+    process pool the owning worker is asked to interrupt Terraform through its
+    normal shutdown handling.
     """
 
     def __init__(
@@ -39,11 +40,13 @@ class AsyncTerraformCommand:
         cwd=None,
         executor: Optional[Executor] = None,
         pool: Optional[TerraformPool] = None,
+        backend: str = "process",
     ):
         self.cwd = cwd
         self.executor = executor
         self._pool = pool
-        self._sync_cli = TerraformCommand(cwd)
+        self.backend = backend
+        self._sync_cli = TerraformCommand(cwd, backend=backend)
 
     def __getattr__(self, name: str) -> Any:
         if name.startswith("_"):
@@ -103,6 +106,7 @@ class AsyncTerraformCommand:
         json=False,
         executor: Optional[Executor] = None,
         pool: Optional[TerraformPool] = None,
+        backend: str = "process",
     ) -> Tuple[int, str, str]:
         """Run command with args without blocking the event loop."""
 
@@ -126,6 +130,7 @@ class AsyncTerraformCommand:
             chdir=chdir,
             check=check,
             json=json,
+            backend=backend,
             executor=executor,
         )
 

--- a/src/libterraform/cli.py
+++ b/src/libterraform/cli.py
@@ -1,8 +1,12 @@
 import os
+import pickle
+import subprocess
+import sys
+import tempfile
 import uuid
 from contextvars import ContextVar
 from ctypes import POINTER, c_char_p, c_int, c_int64
-from threading import Thread
+from threading import Lock, Thread
 from typing import List, Optional, Sequence, Tuple, Union
 
 from libterraform import _lib_tf
@@ -40,11 +44,45 @@ _current_run_id: ContextVar[Optional[str]] = ContextVar(
     default=None,
 )
 
+_PROCESS_BACKEND = "process"
+_THREAD_BACKEND = "thread"
+_BACKENDS = frozenset({_PROCESS_BACKEND, _THREAD_BACKEND})
+_process_runs = {}
+_process_runs_lock = Lock()
+
 
 def _cancel_cli_run(run_id: str) -> int:
+    cancelled = _cancel_process_run(run_id)
     if not run_id or _cancel_cli is None:
-        return 0
-    return _cancel_cli(run_id.encode("utf-8"))
+        return 1 if cancelled else 0
+    native_cancelled = _cancel_cli(run_id.encode("utf-8"))
+    return 1 if cancelled or native_cancelled else 0
+
+
+def _cancel_process_run(run_id: str) -> bool:
+    if not run_id:
+        return False
+    with _process_runs_lock:
+        process = _process_runs.get(run_id)
+    if process is None:
+        return False
+    try:
+        if WINDOWS:
+            process.terminate()
+        else:
+            process.send_signal(2)
+    except ProcessLookupError:
+        pass
+    return True
+
+
+def _normalize_backend(backend: str) -> str:
+    if backend not in _BACKENDS:
+        raise ValueError(
+            f"Unsupported Terraform backend {backend!r}. "
+            f"Expected one of {sorted(_BACKENDS)!r}."
+        )
+    return backend
 
 
 def flag(value):
@@ -115,6 +153,110 @@ def _invoke_cli(argv, w_stdout_fd, w_stderr_fd, run_id=None):
     return _run_cli(argc, c_argv, w_stdout, w_stderr)
 
 
+def _run_argv_in_process(argv, check=False):
+    r_stdout_fd, w_stdout_fd = os.pipe()
+    r_stderr_fd, w_stderr_fd = os.pipe()
+
+    stdout_buffer = []
+    stderr_buffer = []
+    stdout_thread = Thread(
+        target=TerraformCommand._fdread, args=(r_stdout_fd, stdout_buffer)
+    )
+    stdout_thread.daemon = True
+    stdout_thread.start()
+    stderr_thread = Thread(
+        target=TerraformCommand._fdread, args=(r_stderr_fd, stderr_buffer)
+    )
+    stderr_thread.daemon = True
+    stderr_thread.start()
+
+    retcode = _invoke_cli(argv, w_stdout_fd, w_stderr_fd, _current_run_id.get())
+
+    stdout_thread.join()
+    stderr_thread.join()
+    if not stdout_buffer:
+        raise TerraformFdReadError(fd=r_stdout_fd)
+    if not stderr_buffer:
+        raise TerraformFdReadError(fd=r_stderr_fd)
+    stdout = stdout_buffer[0]
+    stderr = stderr_buffer[0]
+
+    if check and retcode not in (0, 2):
+        raise TerraformCommandError(retcode, argv, stdout, stderr)
+    return retcode, stdout, stderr
+
+
+def _run_argv_in_subprocess(argv, check=False):
+    payload = pickle.dumps({"argv": argv}, protocol=pickle.HIGHEST_PROTOCOL)
+    response_path = None
+    run_id = _current_run_id.get()
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="libterraform-worker-", delete=False
+        ) as f:
+            response_path = f.name
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "libterraform._process_worker",
+                "run",
+                response_path,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if run_id:
+            with _process_runs_lock:
+                _process_runs[run_id] = process
+        stdout, stderr = process.communicate(payload)
+        if process.returncode != 0:
+            raise RuntimeError(
+                "libterraform worker process failed "
+                f"with exit code {process.returncode}: "
+                f"{stderr.decode('utf-8', errors='replace')}"
+                f"{stdout.decode('utf-8', errors='replace')}"
+            )
+        with open(response_path, "rb") as f:
+            status, value = pickle.load(f)
+        if status == "error":
+            raise value
+        retcode, stdout_text, stderr_text = value
+        if check and retcode not in (0, 2):
+            raise TerraformCommandError(retcode, argv, stdout_text, stderr_text)
+        return retcode, stdout_text, stderr_text
+    finally:
+        if run_id:
+            with _process_runs_lock:
+                _process_runs.pop(run_id, None)
+        if response_path:
+            try:
+                os.unlink(response_path)
+            except FileNotFoundError:
+                pass
+
+
+def _open_process_stream(argv, run_id):
+    payload = pickle.dumps({"argv": argv}, protocol=pickle.HIGHEST_PROTOCOL)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "libterraform._process_worker",
+            "stream",
+            run_id,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdin is not None
+    process.stdin.write(payload)
+    process.stdin.close()
+    return process
+
+
 def _drain_fd(fd):
     """Read a file descriptor to EOF and return its text."""
     with os.fdopen(fd, encoding="utf-8") as f:
@@ -129,9 +271,8 @@ def _merge_var_options(options, vars, var_files):
         options["var_file"] = var_files
 
 
-# Streaming methods return a TerraformStream (an iterator, not a value), so they
-# are handled specially by the async wrapper and excluded from the process pool
-# (a live stream cannot cross a process boundary).
+# Streaming methods return a TerraformStream (an iterator, not a value), so the
+# async wrapper handles them specially and the process pool omits them.
 _STREAM_METHODS = frozenset({"stream", "plan_stream", "apply_stream"})
 
 
@@ -225,10 +366,11 @@ class TerraformStream:
     cooperative cancellation explicitly.
     """
 
-    def __init__(self, argv, json=True, check=False):
+    def __init__(self, argv, json=True, check=False, backend=_THREAD_BACKEND):
         self._argv = argv
         self._json = json
         self._check = check
+        self._backend = _normalize_backend(backend)
         self._run_id = uuid.uuid4().hex
         self.retcode: Optional[int] = None
         self.stderr: Optional[str] = None
@@ -238,6 +380,7 @@ class TerraformStream:
         self._stderr_result: list = []
         self._cli_thread: Optional[Thread] = None
         self._stderr_thread: Optional[Thread] = None
+        self._process: Optional[subprocess.Popen] = None
 
     def __iter__(self) -> "TerraformStream":
         return self
@@ -262,6 +405,24 @@ class TerraformStream:
 
     def _start(self):
         self._started = True
+        if self._backend == _PROCESS_BACKEND:
+            self._process = _open_process_stream(self._argv, self._run_id)
+            assert self._process.stdout is not None
+            assert self._process.stderr is not None
+            process_stderr = self._process.stderr
+            self._f = open(
+                self._process.stdout.fileno(),
+                encoding="utf-8",
+                closefd=False,
+            )
+            self._stderr_thread = Thread(
+                target=lambda: self._stderr_result.append(
+                    process_stderr.read().decode("utf-8")
+                ),
+                daemon=True,
+            )
+            self._stderr_thread.start()
+            return
         r_stdout_fd, w_stdout_fd = os.pipe()
         r_stderr_fd, w_stderr_fd = os.pipe()
         self._f = os.fdopen(r_stdout_fd, encoding="utf-8")
@@ -279,8 +440,13 @@ class TerraformStream:
         self.retcode = _invoke_cli(self._argv, w_stdout_fd, w_stderr_fd, self._run_id)
 
     def _join(self):
-        assert self._cli_thread is not None and self._stderr_thread is not None
-        self._cli_thread.join()
+        assert self._stderr_thread is not None
+        if self._backend == _PROCESS_BACKEND:
+            assert self._process is not None
+            self.retcode = self._process.wait()
+        else:
+            assert self._cli_thread is not None
+            self._cli_thread.join()
         self._stderr_thread.join()
         self.stderr = self._stderr_result[0] if self._stderr_result else ""
         if self._f is not None:
@@ -299,6 +465,13 @@ class TerraformStream:
 
     def cancel(self):
         """Request cooperative cancellation of the running command."""
+        if self._backend == _PROCESS_BACKEND:
+            if self._process is not None and self._process.poll() is None:
+                if WINDOWS:
+                    self._process.terminate()
+                else:
+                    self._process.send_signal(2)
+            return
         _cancel_cli_run(self._run_id)
 
     def close(self):
@@ -331,8 +504,9 @@ class TerraformCommand:
     https://developer.hashicorp.com/terraform
     """
 
-    def __init__(self, cwd=None):
+    def __init__(self, cwd=None, backend=_PROCESS_BACKEND):
         self.cwd = cwd
+        self.backend = _normalize_backend(backend)
 
     @classmethod
     def run(
@@ -343,6 +517,7 @@ class TerraformCommand:
         chdir=None,
         check: bool = False,
         json=False,
+        backend: str = _PROCESS_BACKEND,
     ) -> Tuple[int, str, str]:
         """
         Run command with args and return a tuple (retcode, stdout, stderr).
@@ -369,35 +544,45 @@ class TerraformCommand:
         :param chdir: Switch to a different working directory before executing the given subcommand.
         :param check: Whether to check return code.
         :param json: Whether to load stdout as json. Only partial commands support json param.
+        :param backend: Execution backend. Defaults to ``"process"`` for
+            process-isolated execution. Use ``"thread"`` to run inside the
+            current process.
         :return: Command result tuple (retcode, stdout, stderr).
         """
+        return cls._run_with_backend(cmd, args, options, chdir, check, json, backend)
+
+    def _run(
+        self,
+        cmd: CmdType,
+        args: Optional[Sequence[str]] = None,
+        options: Optional[dict] = None,
+        chdir=None,
+        check: bool = False,
+        json=False,
+        backend: str = None,
+    ) -> Tuple[int, str, str]:
+        selected_backend = backend or self.backend
+        if selected_backend == _PROCESS_BACKEND:
+            return type(self).run(
+                cmd, args=args, options=options, chdir=chdir, check=check, json=json
+            )
+        return type(self).run(
+            cmd,
+            args=args,
+            options=options,
+            chdir=chdir,
+            check=check,
+            json=json,
+            backend=selected_backend,
+        )
+
+    @staticmethod
+    def _run_with_backend(cmd, args, options, chdir, check, json, backend):
+        selected_backend = _normalize_backend(backend)
         argv = _build_argv(cmd, args, options, chdir, json)
-        r_stdout_fd, w_stdout_fd = os.pipe()
-        r_stderr_fd, w_stderr_fd = os.pipe()
-
-        stdout_buffer = []
-        stderr_buffer = []
-        stdout_thread = Thread(target=cls._fdread, args=(r_stdout_fd, stdout_buffer))
-        stdout_thread.daemon = True
-        stdout_thread.start()
-        stderr_thread = Thread(target=cls._fdread, args=(r_stderr_fd, stderr_buffer))
-        stderr_thread.daemon = True
-        stderr_thread.start()
-
-        retcode = _invoke_cli(argv, w_stdout_fd, w_stderr_fd, _current_run_id.get())
-
-        stdout_thread.join()
-        stderr_thread.join()
-        if not stdout_buffer:
-            raise TerraformFdReadError(fd=r_stdout_fd)
-        if not stderr_buffer:
-            raise TerraformFdReadError(fd=r_stderr_fd)
-        stdout = stdout_buffer[0]
-        stderr = stderr_buffer[0]
-
-        if check and retcode not in (0, 2):
-            raise TerraformCommandError(retcode, argv, stdout, stderr)
-        return retcode, stdout, stderr
+        if selected_backend == _THREAD_BACKEND:
+            return _run_argv_in_process(argv, check)
+        return _run_argv_in_subprocess(argv, check)
 
     @staticmethod
     def _fdread(std_fd, std_buffer):
@@ -428,7 +613,7 @@ class TerraformCommand:
         :param check: Whether to raise on a non ``0``/``2`` exit code at the end.
         """
         argv = _build_argv(cmd, args, options, chdir, json)
-        return TerraformStream(argv, json=json, check=check)
+        return TerraformStream(argv, json=json, check=check, backend=self.backend)
 
     def plan_stream(
         self,
@@ -484,7 +669,7 @@ class TerraformCommand:
         :param json: Whether to load stdout as json.
         :param options: More command options.
         """
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "version", options=options, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -597,7 +782,7 @@ class TerraformCommand:
             ),
             create_default_workspace=create_default_workspace,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "init", options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr)
@@ -659,7 +844,7 @@ class TerraformCommand:
             var=vars,
             var_file=var_files,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "validate", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -770,7 +955,7 @@ class TerraformCommand:
             parallelism=parallelism,
             state=state,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "plan", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -811,7 +996,7 @@ class TerraformCommand:
             generate_config_out=generate_config_out,
             no_color=flag(no_color),
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "query", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -849,7 +1034,7 @@ class TerraformCommand:
             var_file=var_files,
         )
         args = [path] if path else None
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "show", args, options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -939,7 +1124,7 @@ class TerraformCommand:
             var_file=var_files,
         )
         args = [plan] if plan else None
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "apply", args, options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -1009,7 +1194,7 @@ class TerraformCommand:
             state=state,
             state_out=state_out,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "destroy", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -1072,7 +1257,7 @@ class TerraformCommand:
                 args = [dir]
         else:
             args = None
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "fmt", args, options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr, json=False)
@@ -1105,7 +1290,7 @@ class TerraformCommand:
             force=flag(force),
         )
         args = [lock_id]
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "force-unlock", args, options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr, json=False)
@@ -1151,7 +1336,7 @@ class TerraformCommand:
             var=vars,
             var_file=var_files,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "get", options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr, json=False)
@@ -1216,7 +1401,7 @@ class TerraformCommand:
             var=vars,
             var_file=var_files,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "graph", options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr, json=False)
@@ -1296,7 +1481,7 @@ class TerraformCommand:
             ignore_remote_version=flag(ignore_remote_version),
         )
         args = [addr, id]
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "import", args, options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr, json=False)
@@ -1335,7 +1520,7 @@ class TerraformCommand:
             raw=flag(raw),
         )
         args = [name] if name else None
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "output", args, options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -1367,7 +1552,7 @@ class TerraformCommand:
             var=vars,
             var_file=var_files,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "modules", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -1407,7 +1592,7 @@ class TerraformCommand:
         cmd = ["providers"]
         if subcmd:
             cmd.append(subcmd)
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             cmd, args=args, options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -1595,7 +1780,7 @@ class TerraformCommand:
             no_color=flag(no_color),
             parallelism=parallelism,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "refresh", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -1635,7 +1820,7 @@ class TerraformCommand:
             no_color=flag(no_color),
         )
         cmd = ["state", subcmd]
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             cmd, args=args, options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout) if json else stdout
@@ -1798,7 +1983,7 @@ class TerraformCommand:
             no_color=flag(no_color),
         )
         cmd = ["state", "pull"]
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             cmd, options=options, chdir=self.cwd, check=check
         )
         json = retcode == 0
@@ -2000,7 +2185,7 @@ class TerraformCommand:
             no_color=flag(no_color),
             plugin_cache_dir=plugin_cache_dir,
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "stacks", args=args, options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr)
@@ -2059,7 +2244,7 @@ class TerraformCommand:
             lock_timeout=lock_timeout,
             ignore_remote_version=flag(ignore_remote_version),
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "taint", args=[addr], options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr)
@@ -2109,7 +2294,7 @@ class TerraformCommand:
             lock_timeout=lock_timeout,
             ignore_remote_version=flag(ignore_remote_version),
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "untaint", args=[addr], options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr)
@@ -2181,7 +2366,7 @@ class TerraformCommand:
             verbose=flag(verbose),
             allow_deferral=flag(allow_deferral),
         )
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             "test", options=options, chdir=self.cwd, check=check, json=json
         )
         value = json_loads(stdout, split=True) if json else stdout
@@ -2209,7 +2394,7 @@ class TerraformCommand:
             no_color=flag(no_color),
         )
         cmd = ["workspace", subcmd]
-        retcode, stdout, stderr = self.run(
+        retcode, stdout, stderr = self._run(
             cmd, args=args, options=options, chdir=self.cwd, check=check
         )
         return CommandResult(retcode, stdout, stderr)
@@ -2330,3 +2515,27 @@ class TerraformCommand:
         return self.workspace(
             "delete", args=[name], check=check, no_color=no_color, **options
         )
+
+
+class ProcessTerraformCommand(TerraformCommand):
+    """Terraform command API using process-isolated execution."""
+
+    def __init__(self, cwd=None):
+        super().__init__(cwd=cwd, backend=_PROCESS_BACKEND)
+
+    @classmethod
+    def run(cls, *args, **kwargs):
+        kwargs.setdefault("backend", _PROCESS_BACKEND)
+        return super().run(*args, **kwargs)
+
+
+class ThreadTerraformCommand(TerraformCommand):
+    """Terraform command API using the current Python process."""
+
+    def __init__(self, cwd=None):
+        super().__init__(cwd=cwd, backend=_THREAD_BACKEND)
+
+    @classmethod
+    def run(cls, *args, **kwargs):
+        kwargs.setdefault("backend", _THREAD_BACKEND)
+        return super().run(*args, **kwargs)

--- a/src/libterraform/pool.py
+++ b/src/libterraform/pool.py
@@ -122,7 +122,7 @@ def _invoke_method(cwd, name, args, kwargs, run_id):
     """Run a TerraformCommand instance method inside a worker process."""
 
     def call():
-        cli = TerraformCommand(cwd)
+        cli = TerraformCommand(cwd, backend="thread")
         return getattr(cli, name)(*args, **kwargs)
 
     return _run_with_cancel(run_id, call)
@@ -130,6 +130,8 @@ def _invoke_method(cwd, name, args, kwargs, run_id):
 
 def _invoke_run(args, kwargs, run_id):
     """Run TerraformCommand.run inside a worker process."""
+    kwargs = dict(kwargs)
+    kwargs.setdefault("backend", "thread")
     return _run_with_cancel(run_id, lambda: TerraformCommand.run(*args, **kwargs))
 
 

--- a/tests/cli/test_process_backend.py
+++ b/tests/cli/test_process_backend.py
@@ -1,0 +1,97 @@
+import asyncio
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from libterraform import (
+    AsyncTerraformCommand,
+    ProcessTerraformCommand,
+    TerraformCommand,
+    ThreadTerraformCommand,
+)
+from tests.cli.conftest import prepare_sleep_module
+
+
+def _changed_cwd_samples(original_cwd, future):
+    changed = []
+    while not future.done():
+        current = os.getcwd()
+        if current != original_cwd:
+            changed.append(current)
+        time.sleep(0.05)
+    return changed
+
+
+def test_terraform_command_defaults_to_process_backend_for_cwd_isolation(tmp_path):
+    module = prepare_sleep_module(tmp_path / "sync-process-default")
+    original_cwd = os.getcwd()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            lambda: TerraformCommand(module).apply(
+                check=True,
+                json=False,
+                vars={"time1": "2s", "time2": "2s"},
+            )
+        )
+        changed = _changed_cwd_samples(original_cwd, future)
+        result = future.result(timeout=10)
+
+    assert result.retcode == 0
+    assert os.getcwd() == original_cwd
+    assert changed == []
+
+
+def test_explicit_command_classes_select_their_backend():
+    assert ProcessTerraformCommand().backend == "process"
+    assert ThreadTerraformCommand().backend == "thread"
+
+
+def test_terraform_command_thread_backend_remains_available(tmp_path):
+    module = prepare_sleep_module(tmp_path / "sync-thread-backend")
+    original_cwd = os.getcwd()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            lambda: TerraformCommand(module, backend="thread").apply(
+                check=True,
+                json=False,
+                vars={"time1": "2s", "time2": "2s"},
+            )
+        )
+        changed = _changed_cwd_samples(original_cwd, future)
+        result = future.result(timeout=10)
+
+    assert result.retcode == 0
+    assert os.getcwd() == original_cwd
+    assert changed
+
+
+@pytest.mark.asyncio
+async def test_async_terraform_command_defaults_to_process_backend_for_cwd_isolation(
+    tmp_path,
+):
+    module = prepare_sleep_module(tmp_path / "async-process-default")
+    original_cwd = os.getcwd()
+
+    async_cli = AsyncTerraformCommand(module)
+    task = asyncio.create_task(
+        async_cli.apply(
+            check=True,
+            json=False,
+            vars={"time1": "2s", "time2": "2s"},
+        )
+    )
+    changed = []
+    while not task.done():
+        current = os.getcwd()
+        if current != original_cwd:
+            changed.append(current)
+        await asyncio.sleep(0.05)
+    result = await task
+
+    assert result.retcode == 0
+    assert os.getcwd() == original_cwd
+    assert changed == []

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -239,7 +239,7 @@ def test_docs_include_0_15_version_mapping():
     chinese_policy = read_text("docs/zh/release-policy.md")
 
     for page in [english_index, chinese_index]:
-        assert "libterraform/0.15.2/" in page
+        assert "libterraform/0.15.3/" in page
         assert "terraform/tree/v1.15.5" in page
 
     assert "`0.15.x` | `1.15.x` | `release/0.15`" in english_policy

--- a/tests/test_upstream_inspection.py
+++ b/tests/test_upstream_inspection.py
@@ -50,5 +50,5 @@ def test_inspection_cli_outputs_json():
 
     report = json.loads(output)
 
-    assert report["release_matrix"]["current"]["libterraform_version"] == "0.15.2"
+    assert report["release_matrix"]["current"]["libterraform_version"] == "0.15.3"
     assert "command_contract" in report

--- a/tests/test_wheel_distribution.py
+++ b/tests/test_wheel_distribution.py
@@ -4,7 +4,7 @@ from scripts import normalize_wheel_tags
 def test_normalize_linux_wheel_tags_rewrites_linux_platform_tag(tmp_path):
     dist = tmp_path / "dist"
     dist.mkdir()
-    wheel = dist / "libterraform-0.15.2-cp314-cp314-linux_x86_64.whl"
+    wheel = dist / "libterraform-0.15.3-cp314-cp314-linux_x86_64.whl"
     wheel.write_text("wheel", encoding="utf-8")
 
     renamed = normalize_wheel_tags.normalize_wheel_tags(dist)
@@ -12,18 +12,18 @@ def test_normalize_linux_wheel_tags_rewrites_linux_platform_tag(tmp_path):
     assert renamed == [
         (
             wheel,
-            dist / "libterraform-0.15.2-cp314-cp314-manylinux_2_35_x86_64.whl",
+            dist / "libterraform-0.15.3-cp314-cp314-manylinux_2_35_x86_64.whl",
         )
     ]
     assert not wheel.exists()
-    assert (dist / "libterraform-0.15.2-cp314-cp314-manylinux_2_35_x86_64.whl").exists()
+    assert (dist / "libterraform-0.15.3-cp314-cp314-manylinux_2_35_x86_64.whl").exists()
 
 
 def test_normalize_linux_wheel_tags_leaves_non_linux_wheels_unchanged(tmp_path):
     dist = tmp_path / "dist"
     dist.mkdir()
-    macos_wheel = dist / "libterraform-0.15.2-cp314-cp314-macosx_14_0_arm64.whl"
-    manylinux_wheel = dist / "libterraform-0.15.2-cp314-cp314-manylinux_2_35_x86_64.whl"
+    macos_wheel = dist / "libterraform-0.15.3-cp314-cp314-macosx_14_0_arm64.whl"
+    manylinux_wheel = dist / "libterraform-0.15.3-cp314-cp314-manylinux_2_35_x86_64.whl"
     macos_wheel.write_text("wheel", encoding="utf-8")
     manylinux_wheel.write_text("wheel", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Default `TerraformCommand` and `AsyncTerraformCommand` to a process backend so Terraform internal `chdir` calls do not affect the parent Python process.
- Keep current-process execution available with `backend="thread"`, plus explicit `ProcessTerraformCommand` and `ThreadTerraformCommand` aliases.
- Add cwd-isolation regression tests, update English/Chinese docs, and bump `libterraform` to `0.15.3`.

Fixes #11

## Validation
- `git diff --check`
- `uv run ruff format --check src tests scripts`
- `uv run ruff check src tests scripts`
- `uv run ty check src tests scripts`
- `uv run pytest --color=yes`
- `make doc-build`
- `uv build --wheel`